### PR TITLE
Optional CultureInfo parameter to CatalogClient consturctor

### DIFF
--- a/Poushec.UpdateCatalogParser/CatalogClient.cs
+++ b/Poushec.UpdateCatalogParser/CatalogClient.cs
@@ -9,6 +9,7 @@ using Poushec.UpdateCatalogParser.Exceptions;
 using static System.Web.HttpUtility;
 using Poushec.UpdateCatalogParser.Extensions;
 using System.Threading;
+using System.Globalization;
 
 namespace Poushec.UpdateCatalogParser
 {
@@ -21,13 +22,43 @@ namespace Poushec.UpdateCatalogParser
         private HttpClient _client;
         private CatalogParser _catalogParser;
 
-        public CatalogClient(byte pageReloadAttemptsAllowed = 3) : this(new HttpClient(), pageReloadAttemptsAllowed) { }
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CatalogClient"/> class using the specified <see cref="CultureInfo"/>.
+        /// </summary>
+        /// <param name="cultureInfo">The culture information to use for parsing catalog Dates.</param>
+        /// <remarks>
+        /// This constructor creates a new instance of <see cref="HttpClient"/> internally and initializes the <see cref="CatalogClient"/>
+        /// with the provided culture information.
+        /// The default page reload attempts is 3.
+        /// </remarks>
+        public CatalogClient(CultureInfo cultureInfo) : this(new HttpClient(), cultureInfo) { }
 
-        public CatalogClient(HttpClient client, byte pageReloadAttemptsAllowed = 3)
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CatalogClient"/> class with a default culture ("en-US")
+        /// and a specified number of allowed page reload attempts.
+        /// </summary>
+        /// <param name="pageReloadAttemptsAllowed">The number of page reload attempts allowed. Default is 3.</param>
+        /// <remarks>
+        /// This constructor creates a new instance of <see cref="HttpClient"/> and uses a default culture of "en-US".
+        /// It also allows you to specify the maximum number of page reload attempts allowed.
+        /// </remarks>
+        public CatalogClient(byte pageReloadAttemptsAllowed = 3) : this(new HttpClient(), new CultureInfo("en-US"), pageReloadAttemptsAllowed) { }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CatalogClient"/> class with the specified <see cref="HttpClient"/>, <see cref="CultureInfo"/>,
+        /// and allowed page reload attempts.
+        /// </summary>
+        /// <param name="client">An instance of <see cref="HttpClient"/> to be used for making HTTP requests.</param>
+        /// <param name="cultureInfo">The culture information to use for parsing catalog data.</param>
+        /// <param name="pageReloadAttemptsAllowed">The number of page reload attempts allowed. Default is 3.</param>
+        /// <remarks>
+        /// This constructor allows full control over the HTTP client used for requests, the culture settings, and the number of page reload attempts allowed.
+        /// </remarks>
+        public CatalogClient(HttpClient client, CultureInfo cultureInfo, byte pageReloadAttemptsAllowed = 3)
         {
             _client = client;
             _pageReloadAttempts = pageReloadAttemptsAllowed;
-            _catalogParser = new CatalogParser(client);
+            _catalogParser = new CatalogParser(client, cultureInfo);
         }
         
         /// <summary>

--- a/Poushec.UpdateCatalogParser/CatalogParser.cs
+++ b/Poushec.UpdateCatalogParser/CatalogParser.cs
@@ -4,6 +4,7 @@ using Poushec.UpdateCatalogParser.Extensions;
 using Poushec.UpdateCatalogParser.Models;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Net.Http;
 using System.Text.Json;
@@ -19,10 +20,12 @@ namespace Poushec.UpdateCatalogParser
         private readonly Regex _downloadLinkRegex = new Regex(@"(http[s]?\://dl\.delivery\.mp\.microsoft\.com\/[^\'\""]*)|(http[s]?\://download\.windowsupdate\.com\/[^\'\""]*)|(http[s]://catalog\.s\.download\.windowsupdate\.com.*?(?=\'))");
 
         private readonly HttpClient _httpClient;
+        private readonly CultureInfo _cultureInfo;
 
-        public CatalogParser(HttpClient httpClient)
+        public CatalogParser(HttpClient httpClient, CultureInfo cultureInfo)
         {
             _httpClient = httpClient;
+            _cultureInfo = cultureInfo;
         }
 
         public UpdateInfo CollectUpdateInfoFromDetailsPage(CatalogSearchResult searchResult, HtmlDocument detailsPage)
@@ -204,7 +207,7 @@ namespace Poushec.UpdateCatalogParser
             string title = rowCells[1].InnerText.Trim();
             string products = rowCells[2].InnerText.Trim();
             string classification = rowCells[3].InnerText.Trim();
-            DateTime lastUpdated = DateTime.Parse(rowCells[4].InnerText.Trim());
+            DateTime lastUpdated = DateTime.Parse(rowCells[4].InnerText.Trim(), _cultureInfo);
             string version = rowCells[5].InnerText.Trim();
             string size = rowCells[6].SelectNodes("span")[0].InnerText;
             int sizeInBytes = int.Parse(rowCells[6].SelectNodes("span")[1].InnerHtml);

--- a/Poushec.UpdateCatalogParser/CatalogParser.cs
+++ b/Poushec.UpdateCatalogParser/CatalogParser.cs
@@ -229,7 +229,7 @@ namespace Poushec.UpdateCatalogParser
                 driverProperties.DriverModel = detailsPage.GetElementbyId("ScopedViewHandler_driverModel").InnerText;
                 driverProperties.DriverProvider = detailsPage.GetElementbyId("ScopedViewHandler_driverProvider").InnerText;
                 driverProperties.DriverVersion = detailsPage.GetElementbyId("ScopedViewHandler_version").InnerText;
-                driverProperties.VersionDate = DateTime.Parse(detailsPage.GetElementbyId("ScopedViewHandler_versionDate").InnerText);
+                driverProperties.VersionDate = DateTime.Parse(detailsPage.GetElementbyId("ScopedViewHandler_versionDate").InnerText, _cultureInfo);
             }
             catch (Exception ex)
             {

--- a/Poushec.UpdateCatalogParser/Poushec.UpdateCatalogParser.csproj
+++ b/Poushec.UpdateCatalogParser/Poushec.UpdateCatalogParser.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <PackageId>Poushec.UpdateCatalogParser</PackageId>
-    <Version>4.0.1</Version>
+    <Version>4.0.2</Version>
     <Authors>Poushec</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>

--- a/UpdateCatalogParser.Tests/CatalogSearchTest.cs
+++ b/UpdateCatalogParser.Tests/CatalogSearchTest.cs
@@ -106,5 +106,18 @@ namespace UpdateCatalogParser.Tests
 
             Assert.True(allLinksAreNotEmpty);
         }
+
+        [Trait("Catalog Search", "Tests for Catalog Search queries")]
+        [Theory(DisplayName = "SendSearchQueryAsync throws a FormatException with incorrect CultureInfo")]
+        [InlineData("97f6087b-1190-4e0f-9234-352bcbf520ad")]
+        public async Task Throws_FormatException_With_Incorrect_CultureInfo(string updateId)
+        {
+            var catalogClient = new CatalogClient(new System.Globalization.CultureInfo("uk-UA"));
+
+            await Assert.ThrowsAsync<System.FormatException>(async () =>
+            {
+                await catalogClient.SendSearchQueryAsync(updateId);
+            });
+        }
     }
 }


### PR DESCRIPTION
Added additional optional CultureInfo parameter to the CatalogClient that defaults to `en-US` and will be used to parse dates. 

Closes #7 